### PR TITLE
Adding systemd service to start deamon in background

### DIFF
--- a/install-service.sh
+++ b/install-service.sh
@@ -1,0 +1,4 @@
+SDIR=$HOME/.config/systemd/user/
+sed -i /WorkingDirectory=/c\WorkingDirectory=`pwd` polis-client-admin.service
+cp polis-client-admin.service $SDIR/
+systemctl --user daemon-reload

--- a/polis-client-admin.service
+++ b/polis-client-admin.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Polis Client Admin
+After=network.target
+
+[Service]
+Type=forking
+WorkingDirectory=/home/andrebsguedes/software/polis/polisClientAdmin
+ExecStart=/bin/sh run.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+/usr/bin/node dev-server.js >> polis.log 2>&1 &


### PR DESCRIPTION
Signed-off-by: Andre Guedes <andrebsguedes@gmail.com>
Signed-off-by: eliseuegewarth <eliseuegewarth@gmail.com>

Depends on Systemd

Install service with `./install-service.sh`
Then to run use `systemctl --user start polis-client-admin`
The output is logged to the `polis.log` file